### PR TITLE
Use beautifulsoup4 itself as the dependency, instead of the dummy package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def readme():
 
 setup(
 	name='pdf',
-	version='2020.9.18.2',
+	version='2026.6.29',
 	license='MIT',
 	author='Idin',
 	author_email='py@idin.ca',
@@ -46,7 +46,7 @@ setup(
 		'Topic :: Software Development :: Libraries :: Python Modules'
 	],
 	packages=find_packages(exclude=("jupyter_tests", ".idea", ".git")),
-	install_requires=['pdftotree', 'bs4', 'silverware', 'nltk', 'disk', 'pandas', 'chronometry'],
+	install_requires=['pdftotree', 'beautifulsoup4', 'silverware', 'nltk', 'disk', 'pandas', 'chronometry'],
 	python_requires='~=3.6',
 	zip_safe=True,
 )


### PR DESCRIPTION
The [pypi.org/project/bs4 page](https://pypi.org/project/bs4) recommends that people install beautifulsoup4 instead. The package name that you pip install in Python is not necessarily the same as the module name that you import.